### PR TITLE
Actually pass delta time to update function.

### DIFF
--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -88,7 +88,7 @@ void Engine::update() {
 		}
 		if (m_state) m_state->handleEvent(event);
 	}
-	if (m_state) m_state->update(0);
+	if (m_state) m_state->update(m_delta);
 	if (m_state) m_state->render();
 
 	SDL_GL_SwapWindow(m_window);


### PR DESCRIPTION
m_delta hovers around 33. Indeed, 1000/33 = ~30 FPS.
Consider passing a float value. When I use dt, it's usually in time integration where we tend to think in seconds rather than milliseconds. Tag me in a new issue if you'd like this updated.