### PR TITLE
Clearing screen & mac fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+1. Fork the repository
+    * This gives you a personal copy of the project to play with and add features to.
+2. Clone your fork
+    * You should be cloning something that looks like [your-name]/WyvernsNest
+3. Setup the project
+    * See below
+4. Add your feature
+    * Edit code, add a .png, etc.
+    * Push your changes onto your fork.
+    * Please make sure your code compiles. We do not have an auto-build and test system in place yet.
+5. When done, create a pull request on the main project
+    * Click Pull Requests -> New Pull Request -> compare across forks
+    * base fork should be ianw3214/WyvernsNest, and base should be your sub-team branch
+    * head fork should be [your-name]/WyvernsNest, and compare should be where you added your changes.
+6. Submit your pull request
+    * Keep an eye on it. Changes may be requested.
+    * If changes are requested, commit and push them to your fork.
+    * The pull request will automatically update.
+    * A sub-team lead will accept and merge the code into the main repository.
+    
+* If you are collaborating with a friend on a feature, ask your friend to clone and push to your fork ([your-name]/WyvernsNext). You can add your friend as a collaborator to your fork in the repo settings.
+* If you want to get your personal fork up to date with the main project, make a pull request on your personal branch, but this time, merge the main project into yours!

--- a/src/engine/engine.cpp
+++ b/src/engine/engine.cpp
@@ -63,6 +63,8 @@ bool Engine::init(const char * name, int window_width, int window_height) {
 	// reset m_lastTick for a more accurate first tick
 	m_lastTick = SDL_GetTicks();
 
+	mac_fix = 0;
+
 	return true;
 }
 
@@ -71,6 +73,18 @@ bool Engine::running() const {
 }
 
 void Engine::update() {
+	#ifdef __APPLE__
+	// 200 is an arbitrary number but it consistently works for me
+	if(mac_fix < 200) {
+		mac_fix += 1;
+		SDL_SetWindowSize(m_window, 1279, 720);
+	}	
+		
+	if(mac_fix == 200) {
+		SDL_SetWindowSize(m_window, 1280, 720);
+		mac_fix += 1;
+	}
+	#endif
 
 	// Handle the delta time, only tick when the time threshold is reached
 	m_delta = SDL_GetTicks() - m_lastTick;
@@ -90,6 +104,8 @@ void Engine::update() {
 		}
 		if (m_state) m_state->handleEvent(event);
 	}
+
+	getRenderer()->clear();
 	if (m_state) m_state->update(m_delta);
 	if (m_state) m_state->render();
 

--- a/src/engine/engine.hpp
+++ b/src/engine/engine.hpp
@@ -33,7 +33,6 @@ public:
 
 	// State changing functions
 	void setState(State * state);
-	SDL_Window * m_window;
 
 protected:
 	Engine();

--- a/src/engine/engine.hpp
+++ b/src/engine/engine.hpp
@@ -37,7 +37,7 @@ public:
 protected:
 	Engine();
 	~Engine();
-
+ 
 private:
 	// System objects
 	Renderer * m_renderer;

--- a/src/engine/engine.hpp
+++ b/src/engine/engine.hpp
@@ -33,6 +33,7 @@ public:
 
 	// State changing functions
 	void setState(State * state);
+	SDL_Window * m_window;
 
 protected:
 	Engine();
@@ -43,7 +44,6 @@ private:
 	Renderer * m_renderer;
 
 	// SDL/OpenGL specific objects
-	SDL_Window * m_window;
 	SDL_GLContext m_context;
 
 	// The current state
@@ -59,4 +59,7 @@ private:
 	int m_windowHeight;
 	int m_tickRate;
 	int m_msPerTick;
+
+	// macOS fix
+	int mac_fix;
 };

--- a/src/engine/engine.hpp
+++ b/src/engine/engine.hpp
@@ -44,6 +44,7 @@ private:
 	Renderer * m_renderer;
 
 	// SDL/OpenGL specific objects
+	SDL_Window * m_window;
 	SDL_GLContext m_context;
 
 	// The current state


### PR DESCRIPTION
First of all, I'm not sure why the 3 commits from Oct 6 are there. pls help.

Anyway, `getRenderer()->clear();` is now called when the core engine updates.
This didn't do anything for me so I was googling around and stumbled upon [this](https://stackoverflow.com/questions/51992402/sdl-pollevent-prevents-render-unless-window-moved-or-resized) which basically says nothing will render until the window is resized. I looked into using the metal driver for sdl2 but the only examples I could find were in objective-c so we have a homemade fix. The main idea is that the window is resized to 1279x720 and then back to 1280x720 shortly after. 



